### PR TITLE
Update search regex

### DIFF
--- a/imdbsearch.class.php
+++ b/imdbsearch.class.php
@@ -37,7 +37,7 @@ class imdbsearch extends mdb_base {
     $page = $pageRequest->get();
 
     // Parse & filter results
-    if (preg_match_all('!class="result_text"\s*>\s*<a href="/title/tt(?<imdbid>\d{7})/[^>]*>(?<title>.*?)</a>\s*(\([^\d{4}]\)\s*)?(\((?<year>\d{4})(.*?|)\)|)(?<type>[^<]*)!ims', $page, $matches, PREG_SET_ORDER)) {
+    if (preg_match_all('!class="result_text"\s*>\s*<a href="/title/tt(?<imdbid>\d{7})/[^>]*>(?<title>.*?)</a>\s*(\([^\d]+\)\s*)?(\((?<year>\d{4})(.*?|)\)|)(?<type>[^<]*)!ims', $page, $matches, PREG_SET_ORDER)) {
       foreach ($matches as $match) {
         if (count($results) == $maxResults) {
           break;


### PR DESCRIPTION
Was failing to match years on titles like: Home (II) (2015).

`[^\d{4}]` doesn't seem to work as intended, so just check it's not all numbers.