### PR TITLE
Fix finding poster image on title page

### DIFF
--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -867,7 +867,7 @@ class Title extends MdbBase {
    */
   protected function thumbphoto() {
     $this->getPage("Title");
-    preg_match('!id="img_primary">.*?<img [^>]+src="(.+?)".*?<td id="overview-top"!ims',$this->page["Title"],$match);
+    preg_match('!<img [^>]+src="([^"]+)"[^>]+itemprop="image" />!ims',$this->page["Title"],$match);
     if (empty($match[1])) return FALSE;
     $this->main_thumb = $match[1];
     if ( preg_match('|(.*\._V1).*|iUs',$match[1],$mo) ) {


### PR DESCRIPTION
The regular expression for finding the movie's poster image didn't work with the current imdb DOM anymore. This should fix it.