### PR TITLE
Images won't download with allow_url_fopen=0

### DIFF
--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -916,7 +916,15 @@ class Title extends MdbBase {
       return false;
     }
 
-    $image = @file_get_contents($photo_url);
+    if(function_exists('curl_version')) {
+      $ch = curl_init();
+      curl_setopt($ch, CURLOPT_URL, $photo_url);
+      curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+      $image = curl_exec($ch);
+      curl_close($ch);
+    } else {
+      $image = @file_get_contents($photo_url);
+    }
     if (!$image) {
       $this->logger->warning("Failed to fetch image [$photo_url]");
       return false;


### PR DESCRIPTION
There is some hosts that disable allow_url_fopen for security purposes.
This fix are using cURL as first option and fallbacks to
file_get_contents.

file_get_contents(): https:// wrapper is disabled in the server
configuration by allow_url_fopen=0
file_get_contents(https:/image.jpg): failed to open stream: no suitable
wrapper could be found