### PR TITLE
Added support for HTTP-Proxies in order to enable access from secured…

### DIFF
--- a/src/Imdb/Config.php
+++ b/src/Imdb/Config.php
@@ -109,7 +109,40 @@ class Config {
   public $throwHttpExceptions = true;
 
   #--------------------------------------------------=[ TWEAKING OPTIONS ]=--
-
+ 
+  /**
+   * Enable HTTP-Proxy support
+   * @var bool
+   */
+  public $use_proxy = false;
+  
+  /**
+   * Set hostname of HTTP-Proxy
+   * @var string
+   */
+  public $proxy_host = null;
+  
+  /**
+   * Set port on which HTTP-Proxy is listening
+   * @var int
+   */
+  public $proxy_port = null;
+  
+  /**
+   * Set username for authentication against HTTP-Proxy, if the proxy requires login.
+   * Only basic authentication is supported.
+   * Otherwise leave at default value
+   * @var string
+   */
+  public $proxy_user = null;
+  
+  /**
+   * Set password for authentication against HTTP-Proxy, if the proxy requires login.
+   * Otherwise leave at default value
+   * @var string
+   */
+  public $proxy_pw = '';
+  
   /**
    * Set the default user agent (if none is detected)
    * @var string

--- a/src/Imdb/Request.php
+++ b/src/Imdb/Request.php
@@ -37,6 +37,20 @@ class Request {
     curl_setopt($this->ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($this->ch, CURLOPT_HEADERFUNCTION, array(&$this, "callback_CURLOPT_HEADERFUNCTION"));
 
+    //use HTTP-Proxy
+    if( $config->use_proxy === true )
+    {
+        curl_setopt($this->ch, CURLOPT_PROXY, $config->proxy_host);
+        curl_setopt($this->ch, CURLOPT_PROXYPORT, $config->proxy_port);
+        
+        //Login credentials set?
+        if( !empty($config->proxy_user) && !empty($config->proxy_pw) )
+        {
+            curl_setopt($this->ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+            curl_setopt($this->ch, CURLOPT_PROXYUSERPWD, $config->proxy_user.':'.$config->proxy_pw);
+        }
+    }
+    
     $this->urltoopen = $url;
 
     $this->addHeaderLine('Referer', 'http://' . $config->imdbsite . '/');


### PR DESCRIPTION
Added **support for HTTP-Proxies** in order to enable access from secured  networks and/or to increase anonymity. Additional config variables are introduced to toggle the usage of a proxy server and to store the connection details. The use of proxy does not affect the local cache. Pages are still being cached locally aswell if configured so.

Also support for basic authentication against the proxy server is added, in case the specified proxy requires a valid user.