### PR TITLE
Multiple function fixed and tests created

### DIFF
--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -304,7 +304,7 @@ class Title extends MdbBase {
       if ( preg_match('!<title>.*?\(.*?(\d{4})(\&ndash;|\xe2\x80\x93|-)(\d{4}|\?{4}).*?</title>!i',$this->page['Title'],$match) ) {
         $this->main_yearspan = array('start'=>$match[1],'end'=>$match[3]);
       } else {
-        $this->main_yearspan = array('start'=>$this->year(),'end'=>$this->year());
+        $this->main_yearspan = array('start'=>$this->year(),'end'=>$this->endyear());
       }
     }
     return $this->main_yearspan;
@@ -492,8 +492,8 @@ class Title extends MdbBase {
   public function comment_split() {
     if (empty($this->split_comment)) {
       if ($this->main_comment == "") $comm = $this->comment();
-      if (@preg_match('!<strong[^>]*>(.*?)</strong>.*?<div class="comment-meta">\s*(.*?)\s*\|\s*by\s*(.*?</a>).*?(<p[^>]*>.*?)\s*</div!ims',$this->main_comment,$match)) {
-        @preg_match('!href="(.*?)">(.*)</a!i',$match[3],$author);
+      if (@preg_match('!<strong[^>]*>(.*?)</strong>.*?<div class="comment-meta">\s*(.*?)\s*\|\s*by\s*(.*?</a>).*?<p[^>]*>(.*?)\s*</div!ims',$this->main_comment,$match)) {
+        @preg_match('!href="(.*?)"[^>]*><span[^>]*>(.*)</span!i',$match[3],$author);
         $this->split_comment = array("title"=>$match[1],"date"=>$match[2],"author"=>array("url"=>$author[1],"name"=>$author[2]),"comment"=>trim($match[4]));
       } elseif (@preg_match('!<div class="comment-meta">\s*<meta itemprop="datePublished" content=".+?">\s*(.{10,20})\s*\|\s*by\s*(.*?)\s*&ndash;.*?<div>\s*(.*?)\s*</div>!ims',$this->main_comment,$match)) {
         @preg_match('!href="(.*?)">(.*)</a!i',$match[2],$author);
@@ -539,7 +539,7 @@ class Title extends MdbBase {
   public function keywords() {
     if (empty($this->main_keywords)) {
       $this->getPage("Title");
-      if (preg_match_all('!href="/keyword/.+?"\s*>\s*(.*?)\s*</a>!',$this->page["Title"],$matches))
+      if (preg_match_all('!href="/keyword/.+?"\s*>\s*<span[^>]*>(.*?)</span></a>!',$this->page["Title"],$matches))
         $this->main_keywords = $matches[1];
     }
     return $this->main_keywords;
@@ -855,13 +855,13 @@ class Title extends MdbBase {
       $this->getPage("Title");
       if (@preg_match('!Storyline</h2>\s*\n*<div.*?>\s*\n*<?p?>?(.*?)<?/?p?<h4!ims',$this->page["Title"],$match)) {
         if (preg_match('!(.*?)<em class="nobr">Written by!ims',$match[1],$det))
-          $this->main_storyline = $det[1];
+          $this->main_storyline = trim($det[1]);
         elseif (preg_match('!(.*)\s</p>!ims',$match[1],$det))
-          $this->main_storyline = $det[1];
+          $this->main_storyline = trim($det[1]);
         elseif (preg_match('!(.*)\s<span class="see-more inline">!ims',$match[1],$det))
-          $this->main_storyline = $det[1];
+          $this->main_storyline = trim($det[1]);
         elseif (preg_match('!(.*)\s\|!ims',$match[1],$det))
-          $this->main_storyline = $det[1];
+          $this->main_storyline = trim($det[1]);
         else $this->main_storyine = trim($match[1]);
       }
     }
@@ -1111,7 +1111,7 @@ class Title extends MdbBase {
   public function mpaa_reason() {
    if (empty($this->mpaa_justification)) {
     $this->getPage("ParentalGuide");
-    if (preg_match('!href="/mpaa"\s*>.*?</h5>\s*<div class="info-content">\s*(.*?)\s*</div!ims',$this->page["ParentalGuide"],$match))
+    if (preg_match('!id="mpaa-rating"\s*>\s*<td[^>]*>.*</td>\s*<td[^>]*>(.*)</td>!im',$this->page["ParentalGuide"],$match))
       $this->mpaa_justification = trim($match[1]);
    }
    return $this->mpaa_justification;
@@ -1244,7 +1244,7 @@ class Title extends MdbBase {
     $this->getPage("Taglines");
     if ( $this->page["Taglines"] == "cannot open page" ) return array(); // no such page
     if (preg_match_all('!<div class="soda[^>]+>\s*(.*)\s*</div!U',$this->page["Taglines"],$matches))
-      $this->taglines = $matches[1];
+      $this->taglines = array_map('trim',$matches[1]);
    }
    return $this->taglines;
   }

--- a/tests/TitleTest.php
+++ b/tests/TitleTest.php
@@ -268,29 +268,10 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase {
     public function testComment() {
         //@TODO
     }
-
+    
+    // Taking different comments every time. Need to validate what it should look like.
     public function testComment_split() {
-        $imdb = $this->getImdb("0306414");
-        $comment_split = $imdb->comment_split();
-        $this->assertEquals(
-                array(
-                    'title' => 'best show ever, owns nypd blues, the shield and so on...',
-                    'date' => '6 June 2005',
-                    'author' => array(
-                        'url' => 'http://www.imdb.com/user/ur5421073/?ref_=tt_urv',
-                        'name' => 'critikal'
-                    ),
-                    'comment' => 0
-                ),
-                array(
-                    'title' => $comment_split['title'],
-                    'date' => $comment_split['date'],
-                    'author' => array(
-                        'url' => $comment_split['author']['url'],
-                        'name' => $comment_split['author']['name']
-                    ),
-                    'comment' => strpos($comment_split['comment'], "the wire is definitely the best show ever made. most realistic stuff ever. i takes a couple of episodes to get into it because it's pretty slow")
-                ));
+        //@TODO
     }
 
     public function testMovie_recommendations() {
@@ -410,7 +391,7 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase {
 
     public function testTagline() {
         $imdb = $this->getImdb("0306414");
-        $this->assertEquals('A new case begins... (second season)', $imdb->tagline());
+        $this->assertTrue(in_array($imdb->tagline(),$imdb->taglines()));
     }
 
     public function testSeasons() {
@@ -422,7 +403,7 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase {
         $imdb = $this->getImdb("0306414");
         $this->assertTrue($imdb->is_serial());
     }
-	
+    
     public function test_if_not_Is_serial() {
         $imdb = $this->getImdb();
         $this->assertFalse($imdb->is_serial());

--- a/tests/TitleTest.php
+++ b/tests/TitleTest.php
@@ -17,6 +17,7 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase {
    * 1576699 = Mirrors 2 - recommends "'Mirrors' I"
    * 3110958 = Now You See Me 2 -- Testing german language
    * 107290 = Jurassic Park (location with interesting characters)
+   * 0120737 = The Lord of the Rings: The Fellowship of the Ring (historical mpaa)
    *
    * 0306414 = The Wire (TV / has everything)
    * 1286039 = Stargate Universe (multiple creators)
@@ -170,7 +171,8 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testYearspan() {
-        // @TODO
+        $imdb = $this->getImdb("0306414");
+        $this->assertEquals(array('start'=>2002,'end'=>2008), $imdb->yearspan());
     }
 
     public function testMovieTypes() {
@@ -268,7 +270,27 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testComment_split() {
-        //@TODO
+        $imdb = $this->getImdb("0306414");
+        $comment_split = $imdb->comment_split();
+        $this->assertEquals(
+                array(
+                    'title' => 'best show ever, owns nypd blues, the shield and so on...',
+                    'date' => '6 June 2005',
+                    'author' => array(
+                        'url' => 'http://www.imdb.com/user/ur5421073/?ref_=tt_urv',
+                        'name' => 'critikal'
+                    ),
+                    'comment' => 0
+                ),
+                array(
+                    'title' => $comment_split['title'],
+                    'date' => $comment_split['date'],
+                    'author' => array(
+                        'url' => $comment_split['author']['url'],
+                        'name' => $comment_split['author']['name']
+                    ),
+                    'comment' => strpos($comment_split['comment'], "the wire is definitely the best show ever made. most realistic stuff ever. i takes a couple of episodes to get into it because it's pretty slow")
+                ));
     }
 
     public function testMovie_recommendations() {
@@ -285,11 +307,18 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testKeywords() {
-        //@TODO
+        $imdb = $this->getImdb("0306414");
+        $keywords = $imdb->keywords();
+        $this->assertTrue(in_array('baltimore maryland', $keywords));
+        $this->assertTrue(in_array('police department politics', $keywords));
+        $this->assertTrue(in_array('corruption', $keywords));
+        $this->assertTrue(in_array('homicide department', $keywords));
+        $this->assertTrue(in_array('urban decay', $keywords));
     }
 
     public function testLanguage() {
-        //@TODO
+        $imdb = $this->getImdb("0306414");
+        $this->assertEquals('English', $imdb->language());
     }
 
     public function testLanguages_onelanguage() {
@@ -380,15 +409,23 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testTagline() {
-        //@TODO
+        $imdb = $this->getImdb("0306414");
+        $this->assertEquals('A new case begins... (second season)', $imdb->tagline());
     }
 
     public function testSeasons() {
-        //@TODO
+        $imdb = $this->getImdb("0306414");
+        $this->assertEquals('5', $imdb->seasons());
     }
 
     public function testIs_serial() {
-        //@TODO
+        $imdb = $this->getImdb("0306414");
+        $this->assertTrue($imdb->is_serial());
+    }
+	
+    public function test_if_not_Is_serial() {
+        $imdb = $this->getImdb();
+        $this->assertFalse($imdb->is_serial());
     }
 
     public function testEpisodeTitle() {
@@ -458,7 +495,8 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testStoryline() {
-        //@TODO
+        $imdb = $this->getImdb("0306414");
+        $this->assertEquals(0, strpos($imdb->storyline(),"Set in Baltimore, this show centers around the city's inner-city drug scene. It starts as mid-level drug dealer"));
     }
 
     public function testPhoto_returns_false_if_no_poster() {
@@ -564,15 +602,24 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testMpaa() {
-        //@TODO
+      $imdb = $this->getImdb('0120737');
+      $mpaa = $imdb->mpaa();
+      if( !isset($mpaa['United States']) && $mpaa['United States'] !== '15' ) {
+        $this->assertFalse(true);
+      }
     }
 
     public function testMpaa_hist() {
-        //@TODO
+      $imdb = $this->getImdb('0120737');
+      $mpaa = $imdb->mpaa_hist();
+      if( !isset($mpaa['United States']) && !in_array(array('PG-13','PG-13'),$mpaa['United States'],true) ) {
+        $this->assertFalse(true);
+      }
     }
 
     public function testMpaa_reason() {
-        //@TODO
+      $imdb = $this->getImdb('0120737');
+      $this->assertEquals('Rated PG-13 for epic battle sequences and some scary images', $imdb->mpaa_reason());
     }
 
     public function testProdNotes() {
@@ -657,7 +704,14 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testTaglines() {
-        //@TODO
+        $imdb = $this->getImdb("0306414");
+        $taglines = $imdb->taglines();
+        $this->assertTrue(in_array('A new case begins... (second season)', $taglines));
+        $this->assertTrue(in_array('Rules change. The game remains the same. (third season)', $taglines));
+        $this->assertTrue(in_array('No corner left behind. (fourth season)', $taglines));
+        $this->assertTrue(in_array('Listen carefully (first season)', $taglines));
+        $this->assertTrue(in_array('All in the game. (fifth season)', $taglines));
+        $this->assertTrue(in_array('Read between the lines (season five)', $taglines));
     }
 
     public function testDirector_single() {


### PR DESCRIPTION
I have fixed a couple of function when I wrote some new tests. But I haven't found the use for the second if/elseif in comment_split.

```php
public function comment_split() {
if (empty($this->split_comment)) {
  if ($this->main_comment == "") $comm = $this->comment();
  if (@preg_match('!<strong[^>]*>(.*?)</strong>.*?<div class="comment-meta">\s*(.*?)\s*\|\s*by\s*(.*?</a>).*?<p[^>]*>(.*?)\s*</div!ims',$this->main_comment,$match)) {
    @preg_match('!href="(.*?)"[^>]*><span[^>]*>(.*)</span!i',$match[3],$author);
    $this->split_comment = array("title"=>$match[1],"date"=>$match[2],"author"=>array("url"=>$author[1],"name"=>$author[2]),"comment"=>trim($match[4]));
  } elseif (@preg_match('!<div class="comment-meta">\s*<meta itemprop="datePublished" content=".+?">\s*(.{10,20})\s*\|\s*by\s*(.*?)\s*&ndash;.*?<div>\s*(.*?)\s*</div>!ims',$this->main_comment,$match)) {
    @preg_match('!href="(.*?)">(.*)</a!i',$match[2],$author);
    $this->split_comment = array('title'=>'','date'=>$match[1],'author'=>array("url"=>$author[1],"name"=>$author[2]),"comment"=>trim($match[3]));
  }
}
return $this->split_comment;
}
```
Haven't found a page that uses this one. But I left it unaltered in case we find one.
```php
  } elseif (@preg_match('!<div class="comment-meta">\s*<meta itemprop="datePublished" content=".+?">\s*(.{10,20})\s*\|\s*by\s*(.*?)\s*&ndash;.*?<div>\s*(.*?)\s*</div>!ims',$this->main_comment,$match)) {
    @preg_match('!href="(.*?)">(.*)</a!i',$match[2],$author);
    $this->split_comment = array('title'=>'','date'=>$match[1],'author'=>array("url"=>$author[1],"name"=>$author[2]),"comment"=>trim($match[3]));
  }
```

EDIT: Some of the tests failed when I deleted the cache and made a clean tests. Will look at them again.