### PR TITLE
Change geo-location

### DIFF
--- a/conf/900_localconf.sample
+++ b/conf/900_localconf.sample
@@ -44,6 +44,8 @@ debug = 0
 [proxy]
 ; Enable HTTP-Proxy support
 ; use_proxy = 0
+; Set originating IP address of a client connecting to a web server through an HTTP proxy or a load balancer.
+; ip_address = ''
 ; Set hostname of HTTP-Proxy
 ; proxy_host = ''
 ; Set port on which HTTP-Proxy is listening

--- a/src/Imdb/Config.php
+++ b/src/Imdb/Config.php
@@ -117,6 +117,14 @@ class Config {
   public $use_proxy = false;
   
   /**
+   * Set originating IP address of a client connecting to a web server through an HTTP proxy or a load balancer.
+   * Useful with language for times when Imdb uses your ip address geo-location before Accept-Language header.
+   * If this option is specified, a X-Forwarded-For header with this value will be included in requests to IMDb.
+   * @var string
+   */
+  public $ip_address = '';
+  
+  /**
    * Set hostname of HTTP-Proxy
    * @var string
    */

--- a/src/Imdb/MdbBase.php
+++ b/src/Imdb/MdbBase.php
@@ -72,7 +72,7 @@ class MdbBase extends Config {
 
     if ($config) {
       foreach (array("language","imdbsite","cachedir","usecache","storecache","usezip","converttozip","cache_expire",
-                 "photodir","photoroot","imdb_img_url","debug","throwHttpExceptions","use_proxy",
+                 "photodir","photoroot","imdb_img_url","debug","throwHttpExceptions","use_proxy","ip_address",
                  "proxy_host","proxy_port","proxy_user","proxy_pw","default_agent","force_agent") as $key) {
         $this->$key = $config->$key;
       }

--- a/src/Imdb/Request.php
+++ b/src/Imdb/Request.php
@@ -61,6 +61,8 @@ class Request {
       curl_setopt($this->ch, CURLOPT_USERAGENT, $config->default_agent);
     if ($config->language)
       $this->addHeaderLine('Accept-Language', $config->language);
+    if( $config->ip_address )
+      $this->addHeaderLine('X-Forwarded-For', $config->ip_address);
   }
 
   public function addHeaderLine ($name, $value) {

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -299,7 +299,10 @@ class Title extends MdbBase {
    * @see IMDB page / (TitlePage)
    */
   function yearspan() {
-    return $this->main_yearspan = array('start'=>$this->year(),'end'=>$this->endyear());
+    if ( empty($this->main_yearspan) ) {
+      $this->main_yearspan = array('start'=>$this->year(),'end'=>$this->endyear());
+    }
+    return $this->main_yearspan;
   }
 
   /** Get movie types (if any specified)

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -299,15 +299,7 @@ class Title extends MdbBase {
    * @see IMDB page / (TitlePage)
    */
   function yearspan() {
-    if ( empty($this->main_yearspan) ) {
-      $this->getPage("Title");
-      if ( preg_match('!<title>.*?\(.*?(\d{4})(\&ndash;|\xe2\x80\x93|-)(\d{4}|\?{4}).*?</title>!i',$this->page['Title'],$match) ) {
-        $this->main_yearspan = array('start'=>$match[1],'end'=>$match[3]);
-      } else {
-        $this->main_yearspan = array('start'=>$this->year(),'end'=>$this->endyear());
-      }
-    }
-    return $this->main_yearspan;
+    return $this->main_yearspan = array('start'=>$this->year(),'end'=>$this->endyear());
   }
 
   /** Get movie types (if any specified)


### PR DESCRIPTION
Sometimes your server aren't located in your preferred area (language), so you can use another ip address (preferred a public proxies), for tricking IMDb geo-location system.