### PR TITLE
Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--
+Make sure you are using the latest version available, all patches are made in `branch: master` before a new release have been made. `clone or download` the master branch before submitting a bug report.
+
+Use the "Preview" function above, before submitting your Issue.
+
+Keep the title short and informative.
+Example: mpaa_reason returns empty string
+-->
+
+#### Description
+<!-- 
+Briefly describe your bug, question or requested feature.
+Example: Returning empty string when calling `mpaa_reason`.
+-->
+
+#### Movies / TV-Shows / Person
+<!--
+If you are able please supply the ID: tt2013293
+You are at least required to specify the name: Kaze tachinu
+-->
+
+#### Type
+<!--
+Bug:
+  - All information below are required.
+Question:
+  - Please provide a code example if available.
+  - Fill in "What do you want to do?" and "What is happening?".
+Feature request:
+  - Make an example on how you would like to use the new feature inside `code`.
+  - Make a mock-up on how the feature should return it's data inside "Expected Results".
+  - Remove "Actual Results".
+
+Check the box by placing a [X] inside the empty box [ ].
+-->
+- [ ] Bug
+- [ ] Question
+- [ ] Feature request
+
+#### Code
+```php
+// Avoid posting hundreds of lines of source code.
+// Edit to just the relevant portions.
+```
+
+#### Expected Results / What do you want to do?
+<!-- Example: Should return the string "Rated PG-13 for some disturbing images and smoking". -->
+
+#### Actual Results / What is happening?
+<!-- Example: Returned empty string "". -->


### PR DESCRIPTION
I think we should add a default template for "Issues".

#### Description
Returning empty string when calling `mpaa_reason`.

#### Movies / TV-Shows / Person
tt2013293

#### Type
- [X] Bug
- [ ] Question
- [ ] Feature request

#### Code
```php
$title = new \Imdb\Title(2013293);
$mpaa_reason = $title->mpaa_reason();
```

#### Expected Results / What do you want to do?
Should return the string "Rated PG-13 for some disturbing images and smoking".

#### Actual Results / What is happening?
Returned empty string "".
