### PR TITLE
Extend method Recommendations

### DIFF
--- a/demo/person.php
+++ b/demo/person.php
@@ -12,14 +12,11 @@
 require __DIR__ . "/../bootstrap.php";
 
 if (isset ($_GET["mid"]) && preg_match('/^[0-9]+$/',$_GET["mid"])) {
-  $pid = $_GET["mid"];
   $engine = 'imdb';
 
   $person = new \Imdb\Person($_GET["mid"]);
   $charset = "utf-8";
   $source  = "<B CLASS='active'>IMDB</B>";
-
-  $person->setid ($pid);
 
   echo "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01 Transitional//EN'>\n";
   echo "<HTML><HEAD>\n";

--- a/src/Imdb/MdbBase.php
+++ b/src/Imdb/MdbBase.php
@@ -56,6 +56,9 @@ class MdbBase extends Config {
 
   protected $page = array();
 
+  /**
+   * @var string 7 digit identifier for this person
+   */
   protected $imdbID;
 
   /**
@@ -81,14 +84,17 @@ class MdbBase extends Config {
   }
 
   /**
-   * Setup class for a new IMDB id
-   * @param string id IMDBID of the requested movie
-   * @TODO allow numeric ids and coerce them into 7 digit strings
+   * Set and validate the IMDb ID
+   * @param string id IMDb ID
    */
   protected function setid ($id) {
-    if (!preg_match("/^\d{7}$/",$id)) $this->debug_scalar("<BR>setid: Invalid IMDB ID '$id'!<BR>");
-    $this->imdbID = $id;
-    $this->reset_vars();
+    if (is_numeric($id)) {
+      $this->imdbID = str_pad($id, 7, '0', STR_PAD_LEFT);
+    } elseif (preg_match("/(?:nm|tt)(\d{7})/", $id, $matches)) {
+      $this->imdbID = $matches[1];
+    } else {
+      $this->debug_scalar("<BR>setid: Invalid IMDB ID '$id'!<BR>");
+    }
   }
 
   /**
@@ -135,13 +141,6 @@ class MdbBase extends Config {
    */
   protected function buildUrl($context = null) {
     return '';
-  }
-
-  /**
-   * Reset page vars
-   */
-  protected function reset_vars() {
-    return;
   }
 
 }

--- a/src/Imdb/MdbBase.php
+++ b/src/Imdb/MdbBase.php
@@ -83,11 +83,9 @@ class MdbBase extends Config {
   /**
    * Setup class for a new IMDB id
    * @param string id IMDBID of the requested movie
-   * @TODO remove this / make it private
    * @TODO allow numeric ids and coerce them into 7 digit strings
-   * @TODO why is this in mdbbase when the base has no id ...
    */
-  public function setid ($id) {
+  protected function setid ($id) {
     if (!preg_match("/^\d{7}$/",$id)) $this->debug_scalar("<BR>setid: Invalid IMDB ID '$id'!<BR>");
     $this->imdbID = $id;
     $this->reset_vars();
@@ -96,7 +94,6 @@ class MdbBase extends Config {
   /**
    * Retrieve the IMDB ID
    * @return string id IMDBID currently used
-   * @TODO why is this in mdbbase when the base has no id ...
    */
   public function imdbid() {
     return $this->imdbID;

--- a/src/Imdb/Person.php
+++ b/src/Imdb/Person.php
@@ -36,6 +36,44 @@ class Person extends MdbBase {
     'Video documentary' => Title::VIDEO
   );
 
+  // "Name" page:
+  protected $main_photo      = "";
+  protected $fullname        = "";
+  protected $birthday        = array();
+  protected $deathday        = array();
+  protected $allfilms        = array();
+  protected $actressfilms    = array();
+  protected $actorsfilms     = array();
+  protected $producersfilms  = array();
+  protected $soundtrackfilms = array();
+  protected $directorsfilms  = array();
+  protected $crewsfilms      = array();
+  protected $thanxfilms      = array();
+  protected $writerfilms     = array();
+  protected $selffilms       = array();
+  protected $archivefilms    = array();
+
+    // "Bio" page:
+  protected $birth_name      = "";
+  protected $nick_name       = array();
+  protected $bodyheight      = array();
+  protected $spouses         = array();
+  protected $bio_bio         = array();
+  protected $bio_trivia      = array();
+  protected $bio_tm          = array();
+  protected $bio_salary      = array();
+
+    // "Publicity" page:
+  protected $pub_prints      = array();
+  protected $pub_movies      = array();
+  protected $pub_interviews  = array();
+  protected $pub_articles    = array();
+  protected $pub_pictorial   = array();
+  protected $pub_magcovers   = array();
+
+    // SearchDetails
+  protected $SearchDetails   = array();
+
   public static function fromSearchResults($id, $name, Config $config) {
     $person = new self($id, $config);
     $person->fullname = $name;
@@ -50,6 +88,14 @@ class Person extends MdbBase {
     parent::__construct($config);
     $this->revision = preg_replace('|^.*?(\d+).*$|','$1','$Revision$');
     $this->setid($id);
+  }
+
+  /**
+   * Retrieve the IMDB ID
+   * @return string id IMDBID currently used
+   */
+  public function imdbid() {
+    return $this->imdbID;
   }
 
  #-----------------------------------------------[ URL to person main page ]---
@@ -775,50 +821,6 @@ class Person extends MdbBase {
    */
   public function getSearchDetails() {
     return $this->SearchDetails;
-  }
-
-  protected function reset_vars() {
-   $this->page["Name"] = "";
-   $this->page["Bio"]  = "";
-   $this->page["Publicity"]  = "";
-
-   // "Name" page:
-   $this->main_photo      = "";
-   $this->fullname        = "";
-   $this->birthday        = array();
-   $this->deathday        = array();
-   $this->allfilms        = array();
-   $this->actressfilms    = array();
-   $this->actorsfilms     = array();
-   $this->producersfilms  = array();
-   $this->soundtrackfilms = array();
-   $this->directorsfilms  = array();
-   $this->crewsfilms      = array();
-   $this->thanxfilms      = array();
-   $this->writerfilms     = array();
-   $this->selffilms       = array();
-   $this->archivefilms    = array();
-
-   // "Bio" page:
-   $this->birth_name      = "";
-   $this->nick_name       = array();
-   $this->bodyheight      = array();
-   $this->spouses         = array();
-   $this->bio_bio         = array();
-   $this->bio_trivia      = array();
-   $this->bio_tm          = array();
-   $this->bio_salary      = array();
-
-   // "Publicity" page:
-   $this->pub_prints      = array();
-   $this->pub_movies      = array();
-   $this->pub_interviews  = array();
-   $this->pub_articles    = array();
-   $this->pub_pictorial   = array();
-   $this->pub_magcovers   = array();
-
-   // SearchDetails
-   $this->SearchDetails   = array();
   }
 
   /**

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -30,11 +30,6 @@ class Title extends MdbBase {
   const VIDEO = 'Video';
   const SHORT = 'Short';
 
-  /**
-   * @var string 7 digit identifier for this title
-   */
-  protected $imdbID;
-
   protected $akas = array();
   protected $awards = array();
   protected $countries = array();
@@ -168,20 +163,6 @@ class Title extends MdbBase {
   public function __construct($id, Config $config = null) {
     parent::__construct($config);
     $this->setid($id);
-  }
-
-  /**
-   * Set and validate the IMDb ID
-   * @param string id IMDb ID
-   */
-  protected function setid ($id) {
-    if (is_numeric($id)) {
-      $this->imdbID = str_pad($id, 7, '0', STR_PAD_LEFT);
-    } elseif (preg_match("/tt(\d{7})/", $id, $matches)) {
-      $this->imdbID = $matches[1];
-    } else {
-      $this->debug_scalar("<BR>setid: Invalid IMDB ID '$id'!<BR>");
-    }
   }
 
  #-------------------------------------------------------------[ Open Page ]---

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -1669,15 +1669,17 @@ class Title extends MdbBase {
    * @version Attention: Starting with revision 506 (version 2.1.3), the outer array no longer starts at 0 but reflects the real season number!
    */
   public function episodes() {
-    if ( !$this->is_serial() && !$this->seasons() ) return $this->season_episodes;
-    if ( empty($this->season_episodes) ) {
-      if ( !$this->seasons() ) {
+    if (!$this->is_serial() && !$this->seasons()) {
+        return array();
+    }
+
+    if (empty($this->season_episodes)) {
+      if (!$this->seasons()) {
         $ser = $this->get_episode_details();
-        $tid = $this->imdbID;
-        if (isset($ser['imdbid'])) $this->imdbID = $ser['imdbid'];
-        else return $this->season_episodes;
-      } else {
-        $tid = $this->imdbID;
+        if (isset($ser['imdbid'])) {
+          $show = new Title($ser['imdbid'], $this->config);
+          return $this->season_episodes = $show->episodes();
+        } else return array();
       }
       $page = $this->getPage("Episodes");
       if (empty($page)) return $this->season_episodes; // no such page
@@ -1706,7 +1708,6 @@ class Title extends MdbBase {
           }
         }
       }
-      $this->imdbID = $tid;
     }
     return $this->season_episodes;
   }

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -30,6 +30,11 @@ class Title extends MdbBase {
   const VIDEO = 'Video';
   const SHORT = 'Short';
 
+  /**
+   * @var string 7 digit identifier for this title
+   */
+  protected $imdbID;
+
   protected $akas = array();
   protected $awards = array();
   protected $countries = array();
@@ -157,7 +162,7 @@ class Title extends MdbBase {
   }
 
   /**
-   * @param string $id IMDBID to use for data retrieval
+   * @param string $id IMDb ID. e.g. 285331 for http://www.imdb.com/title/tt0285331/
    * @param Config $config OPTIONAL override default config
    */
   public function __construct($id, Config $config = null) {
@@ -166,89 +171,17 @@ class Title extends MdbBase {
   }
 
   /**
-   * Reset all in object caching data e.g. page strings and parsed values
+   * Set and validate the IMDb ID
+   * @param string id IMDb ID
    */
-  protected function reset_vars() {
-   $this->page = array();
-
-   $this->akas = array();
-   $this->awards = array();
-   $this->countries = array();
-   $this->castlist = array(); // pilot only
-   $this->crazy_credits = array();
-   $this->credits_cast = array();
-   $this->credits_composer = array();
-   $this->credits_director = array();
-   $this->credits_producer = array();
-   $this->credits_writing = array();
-   $this->extreviews = array();
-   $this->goofs = array();
-   $this->langs = array();
-   $this->langs_full = array();
-   $this->aspectratio = "";
-   $this->main_comment = "";
-   $this->main_genre = "";
-   $this->main_keywords = array();
-   $this->all_keywords = array();
-   $this->main_language = "";
-   $this->main_photo = "";
-   $this->main_thumb = "";
-   $this->main_pictures = array();
-   $this->main_plotoutline = "";
-   $this->main_rating = -1;
-   $this->main_runtime = "";
-   $this->main_movietype = "";
-   $this->main_title = "";
-   $this->original_title = "";
-   $this->main_votes = -1;
-   $this->main_year = -1;
-   $this->main_endyear = -1;
-   $this->main_yearspan = array();
-   $this->main_creator = array();
-   $this->main_tagline = "";
-   $this->main_storyline = "";
-   $this->main_prodnotes = array();
-   $this->main_movietypes = array();
-   $this->main_top250 = -1;
-   $this->moviecolors = array();
-   $this->movieconnections = array();
-   $this->moviegenres = array();
-   $this->moviequotes = array();
-   $this->movierecommendations = array();
-   $this->movieruntimes = array();
-   $this->mpaas = array();
-   $this->mpaas_hist = array();
-   $this->mpaa_justification = "";
-   $this->plot_plot = array();
-   $this->synopsis_wiki = "";
-   $this->release_info = array();
-   $this->seasoncount = -1;
-   $this->season_episodes = array();
-   $this->sound = array();
-   $this->soundtracks = array();
-   $this->split_comment = array();
-   $this->split_plot = array();
-   $this->taglines = array();
-   $this->trailers = array();
-   $this->video_sites = array();
-   $this->soundclip_sites = array();
-   $this->photo_sites = array();
-   $this->misc_sites = array();
-   $this->trivia = array();
-   $this->compcred_prod = array();
-   $this->compcred_dist = array();
-   $this->compcred_special = array();
-   $this->compcred_other = array();
-   $this->parental_guide = array();
-   $this->official_sites = array();
-   $this->locations = array();
-   $this->budget = null;
-   $this->openingWeekend = array();
-   $this->gross = array();
-   $this->weekendGross = array();
-   $this->admissions = array();
-   $this->filmingDates = array();
-   $this->moviealternateversions = array();
+  protected function setid ($id) {
+    if (is_numeric($id)) {
+      $this->imdbID = str_pad($id, 7, '0', STR_PAD_LEFT);
+    } elseif (preg_match("/tt(\d{7})/", $id, $matches)) {
+      $this->imdbID = $matches[1];
+    } else {
+      $this->debug_scalar("<BR>setid: Invalid IMDB ID '$id'!<BR>");
+    }
   }
 
  #-------------------------------------------------------------[ Open Page ]---

--- a/src/MoviePosterDb/Movie.php
+++ b/src/MoviePosterDb/Movie.php
@@ -23,13 +23,15 @@ class Movie extends \Imdb\MdbBase {
 
   protected $image_exts = array('jpg', 'png', 'gif', 'bmp');
 
+  protected $langs = array();
+
   /**
    * @param string id IMDBID to use for data retrieval
+   * @param Config $config OPTIONAL override default config
    */
   public function __construct($id, Config $config = null) {
     parent::__construct($config);
     $this->setid($id);
-    $this->reset_lang();
   }
 
   /**

--- a/tests/TitleTest.php
+++ b/tests/TitleTest.php
@@ -34,6 +34,21 @@ class imdbTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(false, $imdb->usecache);
     }
 
+    public function test_constructor_with_integer_imdbid_is_coerced_to_7_digit_number() {
+      $imdb = new \Imdb\Title(133093);
+      $this->assertEquals('0133093', $imdb->imdbid());
+    }
+
+    public function test_constructor_with_ttxxxxxxx_is_coerced_to_7_digit_number() {
+      $imdb = new \Imdb\Title('tt0133093');
+      $this->assertEquals('0133093', $imdb->imdbid());
+    }
+
+    public function test_constructor_with_url_is_coerced_to_7_digit_number() {
+      $imdb = new \Imdb\Title('http://www.imdb.com/title/tt0133093/');
+      $this->assertEquals('0133093', $imdb->imdbid());
+    }
+
     // @TODO tests for other types
     public function testMovietype_on_movie() {
         $imdb = $this->getImdb();


### PR DESCRIPTION
I hope this is the right place to make a pull request, i don't understand how it al works

It's about issue #157 
And this is a proposal to extend this method. I split up all the year possibilities and created a field for the text like tv series.

The output array is still the same with the exception of 2 extended fields, endyear and type

```
#-------------------------------------------------------[ Recommendations ]---
  /**
   * Get recommended movies (People who liked this...also liked)
   * @return array recommendations (array[title,imdbid,year,endyear,type])
   * @see IMDB page / (TitlePage)
   */
  public function movie_recommendations() {
	if (empty($this->movierecommendations)) {
		$this->getPage("Title");
		if ( preg_match_all('!<div class="rec-title">\s*(.*?)\s*</div>!ims', $this->page["Title"], $matches) ) {
			foreach ($matches[0] as $found){
				if (preg_match('!<a\s+href="/title/tt(\d+)/[^>]*>\s*(.+)\s*</a>!ims',$found,$match)){
					$title = strip_tags($match[2]);
					if (preg_match('!<span class="nobr">\s*(.*?)\s*</span>!ims',$found,$all)){
						$temp = preg_replace('/[^0-9]/','',$all[0]);
						$type = trim(preg_replace('/[^a-z\s]/i','',strip_tags($all[0])));
						if(mb_strlen(trim($temp)) >4){
							$year = trim(substr($temp, 0, 4));
							$endYear = trim(substr($temp, 4));
							$this->movierecommendations[] = array('title'=>$title,'imdbid'=>$match[1],'year'=>$year,'endyear'=>$endYear,'type'=>$type);
						}
						else{
							$year = trim($temp);
							$this->movierecommendations[] = array('title'=>$title,'imdbid'=>$match[1],'year'=>$year,'endyear'=>'','type'=>$type);
						}
					}
					else{
						$this->movierecommendations[] = array('title'=>$title,'imdbid'=>$match[1],'year'=>'','endyear'=>'','type'=>$type);
					}
				}
				else{
					return $this->movierecommendations;
				}
			}
		}
	}
    return $this->movierecommendations;
  }
```
Can you give your thoughts about it?