### PR TITLE
Replacement method for recommendations

### DIFF
--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -477,7 +477,7 @@ class Title extends MdbBase {
  #-------------------------------------------------------[ Recommendations ]---
   /**
    * Get recommended movies (People who liked this...also liked)
-   * @return array recommendations (array[title,imdbid,year,endyear,type])
+   * @return array recommendations (array[title,imdbid,year,endyear])
    * @see IMDB page / (TitlePage)
    */
 public function movie_recommendations() {
@@ -485,33 +485,25 @@ public function movie_recommendations() {
 		$doc = new \DOMDocument();
 		@$doc->loadHTML($this->getPage("Title"));
 		$xp = new \DOMXPath($doc);
-		if ($cells = $xp->query("//div[@id=\"title_recs\"]/div[@class=\"rec_overviews\"]/div[@class=\"rec_overview\"]/div[@class=\"rec_details\"]/div[@class=\"rec-info\"]/div[@class=\"rec-jaw-upper\"]/div[@class=\"rec-title\"]")){
-			foreach ($cells as $cell) {
-				if(preg_match('!tt(\d+)!',$cell->getElementsByTagName('a')->item(0)->getAttribute('href'),$ref)){
-					$movie['title'] = trim($cell->getElementsByTagName('a')->item(0)->nodeValue);
-					$movie['imdbid'] = $ref[1];
-					if($span = $cell->getElementsByTagName('span')->item(0)->nodeValue){
-						$years = preg_replace('/[^0-9]/','',$span);
-						$type = trim(preg_replace('/[^a-z\s]/i','',strip_tags($span)));
-						if(mb_strlen(trim($years)) >4){
-							$movie['year'] = trim(substr($years, 0, 4));
-							$movie['endyear'] = trim(substr($years, 4));
-							$movie['type'] = $type;
-						}
-						else{
-							$movie['year'] = trim($years);
-							$movie['endyear'] = "";
-							$movie['type'] = $type;
-						}
-						$this->movierecommendations[] = $movie;
-					}
-					else{
-						$movie['year'] = "";
-						$movie['endyear'] = "";
-						$movie['type'] = "";
-						$this->movierecommendations[] = $movie;
-					}
+		$cells = $xp->query("//div[@id=\"title_recs\"]//div[@class=\"rec-title\"]");
+		foreach ($cells as $cell) {
+			if(preg_match('!tt(\d+)!',$cell->getElementsByTagName('a')->item(0)->getAttribute('href'),$ref)){
+				$movie['title'] = trim($cell->getElementsByTagName('a')->item(0)->nodeValue);
+				$movie['imdbid'] = $ref[1];
+				$span = $cell->getElementsByTagName('span')->item(0)->nodeValue;
+				if (strpbrk($span, '1234567890') === FALSE){
+					$span = $cell->getElementsByTagName('span')->item(1)->nodeValue;
 				}
+				$years = preg_replace('/[^0-9]/','',$span);
+				if(mb_strlen(trim($years)) >4){
+					$movie['year'] = trim(substr($years, 0, 4));
+					$movie['endyear'] = trim(substr($years, 4));
+				}
+				else{
+					$movie['year'] = trim($years);
+					$movie['endyear'] = "";
+				}
+				$this->movierecommendations[] = $movie;
 			}
 		}
 	}

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -477,29 +477,46 @@ class Title extends MdbBase {
  #-------------------------------------------------------[ Recommendations ]---
   /**
    * Get recommended movies (People who liked this...also liked)
-   * @return array recommendations (array[imdbid,title,year])
+   * @return array recommendations (array[title,imdbid,year,endyear,type])
    * @see IMDB page / (TitlePage)
    */
-  public function movie_recommendations() {
-    if (empty($this->movierecommendations)) {
-      $doc = new \DOMDocument();
-      @$doc->loadHTML($this->getPage("Title"));
-      $xp = new \DOMXPath($doc);
-      $cells = $xp->query("//div[@id=\"title_recs\"]/div[@class=\"rec_overviews\"]/div[@class=\"rec_overview\"]/div[@class=\"rec_details\"]");
-      foreach ($cells as $cell) {
-        preg_match('!tt(\d+)!',$cell->getElementsByTagName('a')->item(0)->getAttribute('href'),$ref);
-        $movie['title'] = trim($cell->getElementsByTagName('a')->item(0)->nodeValue);
-        $movie['imdbid'] = $ref[1];
-        preg_match('!(\d+)!',$cell->getElementsByTagName('span')->item(0)->nodeValue,$ref);
-        if (!isset($ref[1])) {
-          preg_match('!(\d+)!',$cell->getElementsByTagName('span')->item(1)->nodeValue,$ref);
-        }
-        $movie['year'] = $ref[1];
-        $this->movierecommendations[] = $movie;
-      }
-    }
-    return $this->movierecommendations;
-  }
+public function movie_recommendations() {
+	if (empty($this->movierecommendations)) {
+		$doc = new \DOMDocument();
+		@$doc->loadHTML($this->getPage("Title"));
+		$xp = new \DOMXPath($doc);
+		if ($cells = $xp->query("//div[@id=\"title_recs\"]/div[@class=\"rec_overviews\"]/div[@class=\"rec_overview\"]/div[@class=\"rec_details\"]/div[@class=\"rec-info\"]/div[@class=\"rec-jaw-upper\"]/div[@class=\"rec-title\"]")){
+			foreach ($cells as $cell) {
+				if(preg_match('!tt(\d+)!',$cell->getElementsByTagName('a')->item(0)->getAttribute('href'),$ref)){
+					$movie['title'] = trim($cell->getElementsByTagName('a')->item(0)->nodeValue);
+					$movie['imdbid'] = $ref[1];
+					if($span = $cell->getElementsByTagName('span')->item(0)->nodeValue){
+						$years = preg_replace('/[^0-9]/','',$span);
+						$type = trim(preg_replace('/[^a-z\s]/i','',strip_tags($span)));
+						if(mb_strlen(trim($years)) >4){
+							$movie['year'] = trim(substr($years, 0, 4));
+							$movie['endyear'] = trim(substr($years, 4));
+							$movie['type'] = $type;
+						}
+						else{
+							$movie['year'] = trim($years);
+							$movie['endyear'] = "";
+							$movie['type'] = $type;
+						}
+						$this->movierecommendations[] = $movie;
+					}
+					else{
+						$movie['year'] = "";
+						$movie['endyear'] = "";
+						$movie['type'] = "";
+						$this->movierecommendations[] = $movie;
+					}
+				}
+			}
+		}
+	}
+	return $this->movierecommendations;
+}
 
  #--------------------------------------------------------------[ Keywords ]---
   /** Get the keywords for the movie


### PR DESCRIPTION
Re-worked recommendations method because i thought there where parts missing.
The existing method parses only the first year, so in the case of year span (tv series) the closing year was not parsed.
And the existing method didn't parse the text inside the year brackets

The output array contains 2 extra fields, endyear and type.
endyear contains the endyear of example a tv series (if available). 
type contains the text that is sometimes displayed between the year brackets like video, tv series etc.

For existing users there are no changes if they don't want the extra features.

Edit:
I used tabs but it was better to use spaces i guess?