### PR TITLE
fix the max result count on imdb searchs

### DIFF
--- a/src/Imdb/TitleSearch.php
+++ b/src/Imdb/TitleSearch.php
@@ -44,6 +44,10 @@ class TitleSearch extends MdbBase
             }
         }
 
+        // Limit result count
+        if(!is_null($maxResults)){
+            $results = array_slice($results, 0, $maxResults);
+        }
         return $results;
     }
 


### PR DESCRIPTION
The `$maxResults` parameter wasn't used to limit the number of results to return.