### PR TITLE
Fix #111 - TitleSearch::search will stop searching after limit reached

### DIFF
--- a/src/Imdb/TitleSearch.php
+++ b/src/Imdb/TitleSearch.php
@@ -21,9 +21,10 @@ class TitleSearch extends MdbBase
      * @param string $searchTerms
      * @param array $wantedTypes *optional* imdb types that should be returned. Defaults to returning all types.
      *                            The class constants MOVIE,GAME etc should be used e.g. [TitleSearch::MOVIE, TitleSearch::TV_SERIES]
+     * @param integer $maxResults *optional* specifies the maximum number of results for the search. The default is unlimited.
      * @return Title[] array of Title objects
      */
-    public function search($searchTerms, $wantedTypes = null, $maxResults = null)
+    public function search($searchTerms, $wantedTypes = null, $maxResults = -1)
     {
         $results = array();
 
@@ -41,6 +42,10 @@ class TitleSearch extends MdbBase
 
                 $results[] = Title::fromSearchResult($match['imdbid'], $match['title'], $match['year'], $type,
                   $this->config, $this->logger, $this->cache);
+
+                if (count($results) == $maxResults) {
+                    break;
+                }
             }
         }
 

--- a/tests/TitleSearchTest.php
+++ b/tests/TitleSearchTest.php
@@ -124,6 +124,25 @@ class TitleSearchTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($found, "Did not find Home(II) 2015 in search results");
     }
 
+    public function test_maxResults_parameter_limit_results_count()
+    {
+        $search = $this->getimdbsearch();
+        $maxResults = 3;
+
+        $results = $search->search('Inception', array(TitleSearch::MOVIE), $maxResults);
+        
+        $this->assertEquals($maxResults, count($results));
+    }
+
+    public function test_default_maxResults_parameter_will_not_limit_results_count()
+    {
+        $search = $this->getimdbsearch();
+
+        $results = $search->search('Inception', array(TitleSearch::MOVIE));
+        
+        $this->assertGreaterThan(30, count($results));
+    }
+    
     protected function getimdbsearch()
     {
         $config = new Config();

--- a/tests/TitleSearchTest.php
+++ b/tests/TitleSearchTest.php
@@ -126,9 +126,8 @@ class TitleSearchTest extends PHPUnit_Framework_TestCase
 
     public function test_maxResults_parameter_limit_results_count()
     {
-        $search = $this->getimdbsearch();
         $maxResults = 3;
-
+        $search = $this->getimdbsearch();
         $results = $search->search('Inception', array(TitleSearch::MOVIE), $maxResults);
         
         $this->assertEquals($maxResults, count($results));
@@ -137,7 +136,6 @@ class TitleSearchTest extends PHPUnit_Framework_TestCase
     public function test_default_maxResults_parameter_will_not_limit_results_count()
     {
         $search = $this->getimdbsearch();
-
         $results = $search->search('Inception', array(TitleSearch::MOVIE));
         
         $this->assertGreaterThan(30, count($results));


### PR DESCRIPTION
Inside the `TitleSearch` class the `search` method `$maxResults` parameter had no effect (#111).
```php
public function search($searchTerms, $wantedTypes = null, $maxResults = null)
```
There is already an (open) PR (#162) but that is not efficient, because it will still loop through **all** search results and than just remove every unnecessary result to give back the desired number results.

This fix will stop the scraping after the results count reach the `$maxResults` value.
The default behaviour is to not limit the results count so this PR **does not introduce breaking change**.