### PR TITLE
curl close frees up memory

### DIFF
--- a/src/Imdb/Request.php
+++ b/src/Imdb/Request.php
@@ -83,6 +83,7 @@ class Request
         $this->responseHeaders = array();
         curl_setopt($this->ch, CURLOPT_HTTPHEADER, $this->requestHeaders);
         $this->page = curl_exec($this->ch);
+        curl_close($this->ch);
         if ($this->page !== false) {
             return true;
         }


### PR DESCRIPTION
Executing a curl_close($this->ch); in the sendRequest function of the Request class frees up memory, which could be important when using the function in a loop.