### PR TITLE
Fix searched person ID length allways 7

### DIFF
--- a/src/Imdb/PersonSearch.php
+++ b/src/Imdb/PersonSearch.php
@@ -55,7 +55,7 @@ class PersonSearch extends MdbBase
 
         // make sure to catch col #3, not #1 (pic only)
         //                        photo           name                   1=id        2=name        3=details
-        preg_match_all('|<tr.*>\s*<td.*>.*</td>\s*<td.*<a href="/name/nm(\d{7,8})[^>]*>([^<]+)</a>\s*(.*)</td>|Uims',
+        preg_match_all('|<tr.*>\s*<td.*>.*</td>\s*<td.*<a href="/name/nm(\d+?)[^>]*>([^<]+)</a>\s*(.*)</td>|Uims',
           $page, $matches);
         $mc = count($matches[0]);
         $this->logger->debug("[Person Search] $mc matches");

--- a/tests/PersonSearchTest.php
+++ b/tests/PersonSearchTest.php
@@ -22,6 +22,15 @@ class imdb_person_searchTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("Forest Whitaker", $firstResult->name());
     }
 
+    public function test_searching_returns_person_with_id_of_8_char()
+    {
+        $search = $this->getimdbpersonsearch();
+        $results = $search->search('John Zuberek');
+
+        $firstResult = $results[0];
+        $this->assertEquals("11373523", $firstResult->imdbid());
+    }
+
     protected function getimdbpersonsearch()
     {
         $config = new Config();


### PR DESCRIPTION
Fix #201

_The failed tests are not related to my fix (running the tests on the previous commit will fail on the same test cases too)._