### PR TITLE
Enable to return all MPAA ratings

### DIFF
--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -1207,10 +1207,12 @@ class Title extends MdbBase
 
     /**
      * Get the MPAA rating / Parental Guidance / Age rating for this title by country
-     * @return array [country => rating]
+     * @param  bool  $needAll  On false it will return the last rating for each country,
+     *                         otherwise return every value in an array.
+     * @return array [country => rating], or if $needAll true than [country => [rating,]]
      * @see IMDB Parental Guidance page / (parentalguide)
      */
-    public function mpaa()
+    public function mpaa($needAll = false)
     {
         if (empty($this->mpaas)) {
             $this->getPage("ParentalGuide");
@@ -1218,7 +1220,16 @@ class Title extends MdbBase
               $matches)) {
                 $cc = count($matches[0]);
                 for ($i = 0; $i < $cc; ++$i) {
-                    $this->mpaas[$matches[1][$i]] = $matches[2][$i];
+                    if (!$needAll) {
+                        $this->mpaas[$matches[1][$i]] = $matches[2][$i];
+                        continue;
+                    }
+
+                    if (array_key_exists($matches[1][$i], $this->mpaas)) {
+                        array_push($this->mpaas[$matches[1][$i]], $matches[2][$i]);
+                    } else {
+                        $this->mpaas[$matches[1][$i]] = [$matches[2][$i]];
+                    }
                 }
             }
         }

--- a/tests/TitleTest.php
+++ b/tests/TitleTest.php
@@ -805,6 +805,51 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function testMpaa_should_return_the_last_rating_for_each_country_when_no_bool_param()
+    {
+        $imdb = $this->getImdb('0120737');
+        $expected = [
+            'Canada' => 'G',
+            'Germany' => 12,
+        ];
+
+        $mpaa = $imdb->mpaa();
+
+        $this->assertArraySubset($expected, $mpaa);
+    }
+
+    public function testMpaa_on_series_with_multiple_value_for_a_country_should_reserve_all_ratings_when_true_passed()
+    {
+        $imdb = $this->getImdb('436992');
+        $expected = [
+            'Argentina' => [13],
+            'Australia' => ['PG', 'M'],
+            'Brazil' => [10, 12],
+            'Canada' => ['PG', 'G'],
+            'Finland' => ['K-11'],
+            'France' => ['Tous publics'],
+            'Germany' => [12, 16],
+            'India' => ['12+'],
+            'Ireland' => ['G'],
+            'Italy' => ['T'],
+            'Japan' => ['G'],
+            'Netherlands' => [9,6],
+            'New Zealand' => ['PG', 'M'],
+            'Norway' => [12],
+            'Russia' => ['16+'],
+            'Singapore' => ['PG', 'PG13', 'NC16'],
+            'South Africa' => [13],
+            'South Korea' => [15],
+            'Spain' => [13],
+            'United Kingdom' => ['PG', 'U', 12],
+            'United States' => ['TV-PG', 'TV-Y7-FV'],
+        ];
+
+        $mpaa = $imdb->mpaa(true);
+
+        $this->assertEquals($expected, $mpaa);
+    }
+
     public function testMpaa_hist()
     {
         $imdb = $this->getImdb('0120737');
@@ -1883,7 +1928,7 @@ class imdb_titleTest extends PHPUnit_Framework_TestCase
         $config->language = 'En';
         $config->cachedir = realpath(dirname(__FILE__) . '/cache') . '/';
         $config->usezip = false;
-        $config->cache_expire = 3600;
+        $config->cache_expire = 999999;
         $config->debug = false;
         $imdb = new \Imdb\Title($imdbId, $config);
         return $imdb;


### PR DESCRIPTION
``` php
$title = new \Imdb\Title('id');

// should return an array in this format: ['country' => 'last rating for the given country']
$title->mpaa();

/* should return an array in this format:
['country' => [
    'all',
    'possible',
    'rating'
]]
*/
$title->mpaa(true);
```

Closes #196