### PR TITLE
Extensive changes and troubleshooting for compatibility with the new version of the template

### DIFF
--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -761,7 +761,7 @@ class Title extends MdbBase
     {
         if (empty($this->moviecolors)) {
             $this->getPage("Title");
-            if (preg_match_all("|/search/title\?colors=[^>]+?>\s?(.*?)</a|", $this->page["Title"], $matches)) {
+            if (preg_match_all("|/search/title\/?\?colors=[^>]+?>\s?(.*?)</a|", $this->page["Title"], $matches)) {
                 $this->moviecolors = $matches[1];
             }
         }

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -704,6 +704,18 @@ class Title extends MdbBase
     public function genres()
     {
         if (empty($this->moviegenres)) {
+            $xpath = $this->getXpathPage("Title");
+            $extract_genres = $xpath->query("//li[@data-testid='storyline-genres']//li[@class='ipc-inline-list__item']/a");
+            $genres = array();
+            foreach($extract_genres as $genre){
+                if(!empty($genre->nodeValue)){
+                    $genres[] = trim($genre->nodeValue);
+                }
+            }
+            if(count($genres) > 0)
+                $this->moviegenres = $genres;
+        }
+        if (empty($this->moviegenres)) {
             $genres = isset($this->jsonLD()->genre) ? $this->jsonLD()->genre : array();
             if (!is_array($genres)) {
                 $genres = (array)$genres;

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -1024,10 +1024,12 @@ class Title extends MdbBase
         if (preg_match('!<img [^>]+title="[^"]+Poster"[^>]+src="([^"]+)"[^>]+/>!ims', $this->getPage("Title"), $match)
             && !empty($match[1])) {
             $this->main_poster_thumb = $match[1];
-        } elseif (preg_match('#data-testid="hero-media__poster">.*?<img .*?class="ipc-image".*src="(.*?\.jpg)"#im',
-                $this->getPage("Title"), $match)
-            && !empty($match[1])) {
-            $this->main_poster_thumb = $match[1];
+        } else {
+            $xpath = $this->getXpathPage("Title");
+            $thumb = $xpath->query("//div[contains(@class, 'ipc-poster ipc-poster--baseAlt') and contains(@data-testid, 'hero-media__poster')]//img");
+            if(!empty($thumb)){
+                $this->main_poster_thumb = $thumb->item(0)->getAttribute('src');
+            }
         }
     }
 

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -1243,7 +1243,7 @@ class Title extends MdbBase
     {
         if (empty($this->sound)) {
             $this->getPage("Title");
-            if (preg_match_all("|/search/title\?sound_mixes=[^>]+>\s*(.*?)</|", $this->page["Title"], $matches)) {
+            if (preg_match_all("|/search/title\/?\?sound_mixes=[^>]+>\s*(.*?)</|", $this->page["Title"], $matches)) {
                 $this->sound = $matches[1];
             }
         }
@@ -3063,9 +3063,9 @@ class Title extends MdbBase
     public function budget()
     {
         if (empty($this->budget)) {
-            $page = $this->getPage("Title");
-            if (@preg_match("!<h4[^>]+>Budget:</h4>\\$([\d,]+)\n!is", $page, $bud)) { // Opening Weekend
-                $this->budget = intval(str_replace(",", "", $bud[1]));
+            $query = $this->XmlNextJson()->xpath("//productionBudget/budget/amount");
+            if(!empty($query) && isset($query[0])){
+                $this->budget = intval(str_replace(",", "", $query[0]));
             } else {
                 return null;
             }

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -449,9 +449,11 @@ class Title extends MdbBase
     public function aspect_ratio()
     {
         if (empty($this->aspectratio)) {
-            $page = $this->getPage("Title");
-            if (preg_match('!<h4 class="inline">Aspect Ratio:</h4>\s*(.*?)\s+</div>!ims', $page, $match)) {
-                $this->aspectratio = $match[1];
+
+            $xpath = $this->getXpathPage("Title");
+            $extract = $xpath->query("//li[@data-testid='title-techspec_aspectratio']//span[@class='ipc-metadata-list-item__list-content-item']");
+            if($extract && $extract->item(0) != null){
+                $this->aspectratio = trim($extract->item(0)->nodeValue);
             }
         }
         return $this->aspectratio;

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -571,7 +571,7 @@ class Title extends MdbBase
             if($xpath && isset($xpath[0]->edges->e)){
                 foreach ($xpath[0]->edges->e as $record){
                     $movie = array();
-                    $movie['imdbid'] = trim($record->node->id);
+                    $movie['imdbid'] = str_ireplace('tt', '', trim($record->node->id));
                     $movie['title'] = trim($record->node->titleText->text);
                     $movie['originaltitle'] = trim($record->node->originalTitleText->text);
                     $movie['img'] = trim($record->node->primaryImage->url);

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -1788,6 +1788,7 @@ class Title extends MdbBase
             if (empty($dir['name'])) {
                 continue;
             }
+            $dir["name"] = utf8_decode($dir['name']);
             $get_role = $xpath->query(".//a[@data-testid='cast-item-characters-link']/span[1]", $node);
             if ($get_role != null) {
                 $dir["role"] = $get_role->item(0)->nodeValue;

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -487,8 +487,10 @@ class Title extends MdbBase
     public function metacriticRating()
     {
         $page = $this->getPage('Title');
-        if (preg_match('!"metacriticScore.+>\n.+?(\d+)!im', $page, $match)) {
-            return (int)$match[1];
+        $xpath = $this->getXpathPage("Title");
+        $extract = $xpath->query("//span[@class='score-meta']");
+        if($extract && $extract->item(0) != null){
+            return intval(trim($extract->item(0)->nodeValue));
         }
         return null;
     }

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -111,6 +111,7 @@ class Title extends MdbBase
     protected $episodeSeason = null;
     protected $episodeEpisode = null;
     protected $jsonLD = null;
+    protected $XmlNextJson = null;
 
     protected $pageUrls = array(
         "AlternateVersions" => '/alternateversions',
@@ -3142,6 +3143,33 @@ class Title extends MdbBase
         preg_match('#<script type="application/ld\+json">(.+?)</script>#ims', $page, $matches);
         $this->jsonLD = json_decode($matches[1]);
         return $this->jsonLD;
+    }
+
+    protected function arrayToXml($array, &$xml){
+        foreach ($array as $key => $value) {
+            if(is_int($key)){
+                $key = "e";
+            }
+            if(is_array($value)){
+                $label = $xml->addChild($key);
+                $this->arrayToXml($value, $label);
+            }
+            else {
+                $xml->addChild($key, $value);
+            }
+        }
+    }
+    protected function XmlNextJson(){
+        if ($this->XmlNextJson) {
+            return $this->XmlNextJson;
+        }
+        $xpath = $this->getXpathPage("Title");
+        $script = $xpath->query("//script[@id='__NEXT_DATA__']")->item(0)->nodeValue;
+        $decode = json_decode($script, true);
+        $xml = new \SimpleXMLElement('<root/>');
+        $this->arrayToXml($decode, $xml);
+        $this->XmlNextJson = $xml;
+        return $this->XmlNextJson;
     }
 
     /**

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -800,9 +800,10 @@ class Title extends MdbBase
     public function tagline()
     {
         if ($this->main_tagline == "") {
-            $this->getPage("Title");
-            if (@preg_match('!Taglines:</h4>\s*(.*?)\s*<!ims', $this->page["Title"], $match)) {
-                $this->main_tagline = trim($match[1]);
+            $xpath = $this->getXpathPage("Title");
+            $extract = $xpath->query("//li[@data-testid='storyline-taglines']//span[@class='ipc-metadata-list-item__list-content-item']");
+            if($extract && $extract->item(0) != null){
+                $this->main_tagline = trim($extract->item(0)->nodeValue);
             }
         }
         return $this->main_tagline;

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -813,16 +813,13 @@ class Title extends MdbBase
     public function seasons()
     {
         if ($this->seasoncount == -1) {
-            $this->getPage("Title");
-            if (preg_match_all('|href="/title/tt\d{7,8}/episodes\?season=\d+.*?"\s*>(\d+)</a>|Ui', $this->page["Title"],
-                $matches)) {
-                $this->seasoncount = $matches[1][0];
-            } else {
-                $this->seasoncount = 0;
-            }
-            if (preg_match_all('|href="/title/tt\d{7,8}/episodes\?season\=unknown"\s*>unknown</a>|Ui',
-                $this->page["Title"], $matches)) {
-                $this->seasoncount += count($matches[0]);
+            $xpath = $this->getXpathPage("Title");
+            $dom_xpath_result = $xpath->query('//select[@id="browse-episodes-season"]//option');
+            $this->seasoncount = 0;
+            foreach($dom_xpath_result as $xnode){
+                if(!empty($xnode->getAttribute('value')) && intval($xnode->getAttribute('value')) > $this->seasoncount){
+                    $this->seasoncount = intval($xnode->getAttribute('value'));
+                }
             }
         }
         return $this->seasoncount;

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -1029,7 +1029,7 @@ class Title extends MdbBase
         } else {
             $xpath = $this->getXpathPage("Title");
             $thumb = $xpath->query("//div[contains(@class, 'ipc-poster ipc-poster--baseAlt') and contains(@data-testid, 'hero-media__poster')]//img");
-            if(!empty($thumb)){
+            if(!empty($thumb) && $thumb->item(0) != null){
                 $this->main_poster_thumb = $thumb->item(0)->getAttribute('src');
             }
         }

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -420,11 +420,11 @@ class Title extends MdbBase
             $this->movieruntimes = array();
             $rt = $this->runtime_all();
             foreach (preg_split('!(\||<br>)!', strip_tags($rt, '<br>')) as $runtimestring) {
-                if (preg_match_all("/(\d+\s+hr\s+\d+\s+min)?\((\d+)\s+min\)|(\d+)\s+min/", $runtimestring, $matches,
+                if (preg_match_all('/(\d+\s+hr\s+\d+\s+min)? ?\((\d+)\s+min\)|(\d+)\s+min/', trim($runtimestring), $matches,
                     PREG_SET_ORDER, 0)) {
-                    $runtime = isset($matches[1][2]) ? $matches[1][2] : (isset($matches[0][3]) ? $matches[0][3] : 0);
+                    $runtime = isset($matches[1][2]) ? $matches[1][2] : (isset($matches[0][2]) ? $matches[0][2] : 0);
                     $annotations = array();
-                    if (preg_match_all("/\((?!\d+\s+min)(.+?)\)/", $runtimestring, $matches)) {
+                    if (preg_match_all("/\((?!\d+\s+min)(.+?)\)/", trim($runtimestring), $matches)) {
                         $annotations = $matches[1];
                     }
                     $this->movieruntimes[] = array(

--- a/tests/TitleTest.php
+++ b/tests/TitleTest.php
@@ -497,9 +497,9 @@ class TitleTest extends PHPUnit\Framework\TestCase
     // Primary match is to the genre listing just under the title, which this tests
     public function testGenres_multiple()
     {
-        $imdb = $this->getImdb('1375666');
+        $imdb = $this->getImdb('0087544');
         $genres = $imdb->genres();
-        $this->assertTrue(in_array('Action', $genres));
+        $this->assertTrue(in_array('Animation', $genres));
         $this->assertTrue(in_array('Sci-Fi', $genres));
         $this->assertTrue(count($genres) == 4);
     }

--- a/tests/TitleTest.php
+++ b/tests/TitleTest.php
@@ -290,8 +290,9 @@ class TitleTest extends PHPUnit\Framework\TestCase
         $runtimes = $imdb->runtimes();
         $this->assertEquals(117, $runtimes[0]['time']);
         $this->assertEquals(95, $runtimes[1]['time']);
-        $this->assertEquals(1985, $runtimes[1]['annotations'][0]);
-        $this->assertEquals('edited', $runtimes[1]['annotations'][1]);
+        $this->assertEquals('edited', $runtimes[1]['annotations'][0]);
+        $this->assertEquals(1985, $runtimes[1]['annotations'][1]);
+        $this->assertEquals('USA', $runtimes[1]['annotations'][2]);
     }
 
     // Apocalypse now "147 min | 196 min (Redux)"
@@ -696,7 +697,7 @@ class TitleTest extends PHPUnit\Framework\TestCase
     {
         $imdb = $this->getImdb();
         // This is a little brittle. What if the image changes? what if the size of the poster changes? ...
-        $this->assertEquals('https://m.media-amazon.com/images/M/MV5BNzQzOTk3OTAtNDQ0Zi00ZTVkLWI0MTEtMDllZjNkYzNjNTc4L2ltYWdlXkEyXkFqcGdeQXVyNjU0OTQ0OTY@._V1_UX182_CR0,0,182,268_AL_.jpg', $imdb->photo(true));
+        $this->assertEquals('https://m.media-amazon.com/images/M/MV5BNzQzOTk3OTAtNDQ0Zi00ZTVkLWI0MTEtMDllZjNkYzNjNTc4L2ltYWdlXkEyXkFqcGdeQXVyNjU0OTQ0OTY@._V1_QL75_UX190_CR0,2,190,281_.jpg', $imdb->photo(true));
     }
 
     public function testSavephoto()
@@ -780,11 +781,10 @@ class TitleTest extends PHPUnit\Framework\TestCase
         $imdb = $this->getImdb();
         $sound = $imdb->sound();
         $this->assertIsArray($sound);
-        $this->assertCount(4, $sound);
-        $this->assertEquals('DTS', $sound[0]);
-        $this->assertEquals('Dolby Digital', $sound[1]);
-        $this->assertEquals('SDDS', $sound[2]);
-        $this->assertEquals('Dolby Atmos', $sound[3]);
+        $this->assertCount(3, $sound);
+        $this->assertEquals('Dolby Digital', $sound[0]);
+        $this->assertEquals('SDDS', $sound[1]);
+        $this->assertEquals('Dolby Atmos', $sound[2]);
     }
 
     public function testSound_one_type()

--- a/tests/TitleTest.php
+++ b/tests/TitleTest.php
@@ -8,6 +8,7 @@ class TitleTest extends PHPUnit\Framework\TestCase
     /**
      * IMDb IDs for testing:
      * 0133093 = The Matrix (has everything)
+     * 1375666 = Inception (multiple genres)
      * 0087544 = Nausicaa (foreign, nonascii)
      * 0078788 = Apocalypse Now (Two cuts, multiple languages)
      * 0108052 = Schindler's List (multiple colours)
@@ -496,10 +497,11 @@ class TitleTest extends PHPUnit\Framework\TestCase
     // Primary match is to the genre listing just under the title, which this tests
     public function testGenres_multiple()
     {
-        $imdb = $this->getImdb();
+        $imdb = $this->getImdb('1375666');
         $genres = $imdb->genres();
         $this->assertTrue(in_array('Action', $genres));
         $this->assertTrue(in_array('Sci-Fi', $genres));
+        $this->assertTrue(count($genres) == 4);
     }
 
 //    public function testGenres_none()


### PR DESCRIPTION
1- add new method for __NEXT_DATA__ 
2- Fix a problem that shows only 3 genres (and add test for this)
3- more fix with new tamplate


Explain only 3 genres problem:
sample:
https://www.imdb.com/title/tt1375666/

old result:
array (size=3)
  0 => string 'Action'
  1 => string 'Adventure'
  2 => string 'Sci-Fi'

new result:
array (size=4)
  0 => string 'Action'
  1 => string 'Adventure'
  2 => string 'Sci-Fi'
  3 => string 'Thriller'