### PR TITLE
Make budget more reliable

### DIFF
--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -2959,7 +2959,7 @@ class Title extends MdbBase
 
     /**
     * Get budget
-    * @return string|null null on failure / no data
+    * @return int|null null on failure / no data
     * @brief Assuming budget is estimated, and in american dollar
     * @see IMDB page / (TitlePage)
     */
@@ -2970,16 +2970,11 @@ class Title extends MdbBase
             if (empty($xpath)) {
                 return array(); // no such page
             }
-            $labels = $xpath->query("//span[@class=\"ipc-metadata-list-item__label\"]");
-            foreach ($labels as $label) {
-                if ($label->nodeValue == "Budget") {
-                    $budgetListItems = $xpath->query("//li[@class=\"ipc-metadata-list__item BoxOffice__MetaDataListItemBoxOffice-sc-40s2pl-2 gwNUHl\"]//li");
-                    if (!empty($budgetListItems) && isset($budgetListItems[0])) {
-                        $this->budget = filter_var($budgetListItems[0]->nodeValue, FILTER_SANITIZE_NUMBER_INT);
-                    } else {
-                        return null;
-                    }
-                }
+            $budgetListItems = $xpath->query("//li[@data-testid=\"title-boxoffice-budget\"]//li");
+            if (!empty($budgetListItems) && isset($budgetListItems[0])) {
+                $this->budget = (int) filter_var($budgetListItems[0]->nodeValue, FILTER_SANITIZE_NUMBER_INT);
+            } else {
+                return null;
             }
         }
         return $this->budget;

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -2955,20 +2955,31 @@ class Title extends MdbBase
         return $this->awards;
     }
 
-    /*
-  * Get budget
-  * @return int|null null on failure / no data
-  * @brief Assuming budget is estimated, and in american dollar
-  * @see IMDB page / (TitlePage)
-  */
+    #-------------------------------------------------[ Budget ]---
+
+    /**
+    * Get budget
+    * @return string|null null on failure / no data
+    * @brief Assuming budget is estimated, and in american dollar
+    * @see IMDB page / (TitlePage)
+    */
     public function budget()
     {
         if (empty($this->budget)) {
-            $query = $this->XmlNextJson()->xpath("//productionBudget/budget/amount");
-            if (!empty($query) && isset($query[0])) {
-                $this->budget = intval(str_replace(",", "", $query[0]));
-            } else {
-                return null;
+            $xpath = $this->getXpathPage("Title");
+            if (empty($xpath)) {
+                return array(); // no such page
+            }
+            $labels = $xpath->query("//span[@class=\"ipc-metadata-list-item__label\"]");
+            foreach ($labels as $label) {
+                if ($label->nodeValue == "Budget") {
+                    $budgetListItems = $xpath->query("//li[@class=\"ipc-metadata-list__item BoxOffice__MetaDataListItemBoxOffice-sc-40s2pl-2 gwNUHl\"]//li");
+                    if (!empty($budgetListItems) && isset($budgetListItems[0])) {
+                        $this->budget = filter_var($budgetListItems[0]->nodeValue, FILTER_SANITIZE_NUMBER_INT);
+                    } else {
+                        return null;
+                    }
+                }
             }
         }
         return $this->budget;

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -3024,10 +3024,13 @@ class Title extends MdbBase
                 return array(); // no such page
             }
             $budgetListItems = $xpath->query("//li[@data-testid=\"title-boxoffice-budget\"]//li");
-            if (!empty($budgetListItems) && isset($budgetListItems[0])) {
-                $this->budget = (int) filter_var($budgetListItems[0]->nodeValue, FILTER_SANITIZE_NUMBER_INT);
-            } else {
-                return null;
+            if (preg_match('/^(?<currency>[^0-9\s]+)?\s*(?<amount>[0-9,]+)\s*(?<comment>.{1,})?$/',
+                    $budgetListItems->item(0)->nodeValue, $match)) {
+                if (isset($match['amount']) && !empty($match['amount'])) {
+                    $this->budget = intval(str_replace(',', '', $match['amount']));
+                } else {
+                    return null;
+                }
             }
         }
         return $this->budget;


### PR DESCRIPTION
Budget used data from script, this is however not reliable.
Changed it to a more reliable method that scrapes the actual page.

I do have however a few thoughts about this method:
- it assumes that budget is in American dollars but what if it is Canadian or Australian dollars?
- It might be better to return the complete string, that includes the currency and (Estimated) if available, however this will change the output from int to string.