### PR TITLE
method Trivia, fixed html

### DIFF
--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -2326,7 +2326,7 @@ class Title extends MdbBase
                         if ($cells = $xpath->query('.//div[contains(@class, "sodatext")]', $value)) {
                             foreach ($cells as $cell) {
                                 if ($cell->nodeValue != "") {
-                                    $this->trivia[] = utf8_decode(trim($cell->nodeValue));
+                                    $this->trivia[] = trim($cell->nodeValue);
                                 }
                             }
                         }
@@ -2334,7 +2334,7 @@ class Title extends MdbBase
                         if ($cells = $xpath->query('.//div[contains(@class, "sodatext")]', $value)) {
                             foreach ($cells as $cell) {
                                 if ($cell->nodeValue != "") {
-                                    $this->trivia[] = utf8_decode(trim($cell->nodeValue));
+                                    $this->trivia[] = trim($cell->nodeValue);
                                 }
                             }
                         }

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -2326,7 +2326,7 @@ class Title extends MdbBase
                         if ($cells = $xpath->query('.//div[contains(@class, "sodatext")]', $value)) {
                             foreach ($cells as $cell) {
                                 if ($cell->nodeValue != "") {
-                                    $this->trivia[] = trim($cell->nodeValue);
+                                    $this->trivia[] = utf8_decode(trim($cell->nodeValue));
                                 }
                             }
                         }
@@ -2334,7 +2334,7 @@ class Title extends MdbBase
                         if ($cells = $xpath->query('.//div[contains(@class, "sodatext")]', $value)) {
                             foreach ($cells as $cell) {
                                 if ($cell->nodeValue != "") {
-                                    $this->trivia[] = trim($cell->nodeValue);
+                                    $this->trivia[] = utf8_decode(trim($cell->nodeValue));
                                 }
                             }
                         }


### PR DESCRIPTION
- Rewrite to xpath.
- Added back spoilers.
- Output contains no html
I don't know why it stated deprecated in the previous phpdoc, trivia spoilers are available? Maybe hard to maintain? In this method it is quite easy i think.

comments are more than welcome