### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.vscode
 /demo/images
 /.php-cs-fixer.cache
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /vendor
 /cache
 /.idea
+/.vscode
 /demo/images
 /.php-cs-fixer.cache


### PR DESCRIPTION
Prevents developers using Visual Studio Code to accidentally add the local .vscode folder to their commits. Also ignore .DS_Store (useful for macOS users).